### PR TITLE
[CI/CD] Add clang-format workflow

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,62 +1,78 @@
-Language: C
+Language: Cpp
+Standard: Latest
 
-BasedOnStyle: LLVM
 IndentWidth: 4
 TabWidth: 4
 UseTab: Always
 ColumnLimit: 120
 BreakBeforeBraces: Allman
-AllowShortFunctionsOnASingleLine: false
-AllowShortIfStatementsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: Never
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakTemplateDeclarations: Yes
-IndentCaseLabels: false
+IndentCaseLabels: true
+IndentCaseBlocks: false
 IndentGotoLabels: false
-IndentPPDirectives: AfterHash
+IndentPPDirectives: None
 IndentWrappedFunctionNames: false
 SpaceAfterTemplateKeyword: true
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeCpp11BracedList: true
 SpaceBeforeParens: ControlStatements
-SpaceInEmptyParentheses: false
-SpacesBeforeTrailingComments: 1
-SpacesInAngles: false
-SpacesInCStyleCastParentheses: false
-SpacesInContainerLiterals: false
-SpacesInParentheses: false
-Standard: C23
+SpacesBeforeTrailingComments: 4
+SpaceBeforeSquareBrackets: false
+SpacesInParens: Custom
+SpacesInParensOptions:
+  InConditionalStatements: false
+  InEmptyParentheses: false
+  InCStyleCasts: false
+  Other: false
+SpacesInSquareBrackets: false
 
-# Additional configurations to match specific rules
+AlignConsecutiveMacros: AcrossComments
+AlignConsecutiveDeclarations:
+  Enabled: true
+  AcrossEmptyLines: false
+  AlignCompound: true
+  AcrossComments: true
+  AlignFunctionPointers: true
 AlignAfterOpenBracket: Align
 AlignEscapedNewlines: Right
-AlignOperands: true
+AlignOperands: Align
 AlignTrailingComments: true
-BinPackArguments: false
-BinPackParameters: false
+BreakAdjacentStringLiterals: true
+BreakAfterAttributes: Always
+
+BinPackArguments: true
+BinPackParameters: true
+BitFieldColonSpacing: None
 BraceWrapping:
   AfterClass: true
-  AfterControlStatement: true
+  AfterControlStatement: Always
+  AfterCaseLabel: true
   AfterEnum: true
   AfterFunction: true
   AfterNamespace: true
   AfterStruct: true
+  AfterExternBlock: true
   AfterUnion: true
   BeforeCatch: true
   BeforeElse: true
   BeforeLambdaBody: true
   BeforeWhile: true
   IndentBraces: false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
 BreakBeforeBinaryOperators: None
-BreakBeforeTernaryOperators: true
-BreakConstructorInitializersBeforeComma: false
-ConstructorInitializerAllOnOneLineOrOnePerLine: true
-Cpp11BracedListStyle: true
+BreakBeforeTernaryOperators: false
+BreakStringLiterals: false
 DerivePointerAlignment: false
 FixNamespaceComments: true
 PointerAlignment: Left
 SpaceAfterLogicalNot: false
 
 # Custom header sorting
+IncludeBlocks: Regroup
 IncludeCategories:
   - Regex: '^<.*\.h>'
     Priority: 1
@@ -64,30 +80,18 @@ IncludeCategories:
     Priority: 2
   - Regex: '^".*\.h"'
     Priority: 3
-SortIncludes: true
+SortIncludes: CaseInsensitive
 
 # Comment style
 CommentPragmas: '^//.*'
-ReflowComments: false
+ReflowComments: true
 
-# Typedefs and structs
-TypenameMacros: ['typedef', 'struct']
 AllowShortEnumsOnASingleLine: false
-
-# Naming conventions
-VariableCase: lower_case
-FunctionCase: lower_case
-TypeCase: PascalCase
-MacroCase: UPPER_CASE
-
-# Doxygen style comments
-CommentStyle:
-  Doxygen: true
-  Slash: true
 
 # Additional formatting options
 MaxEmptyLinesToKeep: 1
 KeepEmptyLinesAtTheStartOfBlocks: false
-InsertTrailingCommas: false
+InsertTrailingCommas: None
 AllowAllArgumentsOnNextLine: false
 AllowAllParametersOfDeclarationOnNextLine: false
+InsertNewlineAtEOF: true

--- a/.github/workflows/clang-format-check.yaml
+++ b/.github/workflows/clang-format-check.yaml
@@ -1,0 +1,33 @@
+name: clang-format Check
+on:
+  pull_request:
+    types: [opened, review_requested, synchronize]
+    # Only trigger if C source files have been changed.
+    paths:
+    - '**.c'
+    - '**.h'
+
+jobs:
+  formatting-check:
+    name: Formatting Check
+    runs-on: ubuntu-latest
+    steps:
+    # Filter only files changed by the PR.
+    - name: Filter changed files
+      id: filter
+      uses: dorny/paths-filter@v2
+      with:
+        filters: |
+          c_files:
+            - '**.c'
+          h_files:
+            - '**.h'
+    # Check code.
+    - uses: actions/checkout@v4
+    - name: Run clang-format style check for C.
+      if: steps.filter.outputs.c_files == 'true' || steps.filter.outputs.h_files == 'true'
+      uses: jidicula/clang-format-action@v4.13.0
+      with:
+        clang-format-version: '18'
+        check-path: 'kernel'
+        fallback-style: llvm

--- a/kernel/drv/misc/example/main.c
+++ b/kernel/drv/misc/example/main.c
@@ -22,8 +22,7 @@ static void exit()
 	printf("bye!\n");
 }
 
-MENIX_MODULE_INFO
-{
+MENIX_MODULE_INFO {
 	.load = load,
 	.exit = exit,
 };

--- a/kernel/menix/kernel.c
+++ b/kernel/menix/kernel.c
@@ -2,18 +2,18 @@
 Kernel entry point
 ----------------*/
 
-#include <menix/stdio.h>
 #include <menix/arch.h>
-#include <menix/module.h>
-
 #include <menix/config.h>
+#include <menix/module.h>
+#include <menix/stdio.h>
 
 void kernel_main(void)
 {
 	// Init platform.
 	arch_init();
 
-	printf("menix v" MENIX_VERSION " (" MENIX_ARCH ")" "\n");
+	printf("menix v" MENIX_VERSION " (" MENIX_ARCH ")"
+		   "\n");
 
 #if CFG_ENABLED(example)
 	hello_world_say_hello();


### PR DESCRIPTION
## What?

Add a `clang-format` workflow to the repo to check for code style using the existing `.clang-format` file.

This PR uses [this existing workflow](https://github.com/marketplace/actions/clang-format-check) to improve and enforce code quality.

## Links

Fixes: #2 
Tracks: N/A
