### PR TITLE
Add gnu-efi to build dependency

### DIFF
--- a/doc/building.md
+++ b/doc/building.md
@@ -9,6 +9,8 @@ cmake
 clang
 ```
 
+You also need to install the `gnu-efi` package as a build dependency.
+
 ## Building steps
 Create a build directory and configure CMake.
 


### PR DESCRIPTION
# What does this PR change?


Update `build.md` to include `gnu-efi` as a build dependency.

<!-- Provide a short description of what exactly your PR changes here -->

Tick the applicable box:
- [ ] Add new feature
- [ ] Feature iteration
- [ ] Bug Fix
- [ ] Security changes
- [ ] Tests
- [x] Documentation
<br/>

- [ ] General Maintenance

<!-- Other please specify -->

## Reason for adding a new feature

<!-- If you add a new feature, please provide a brief summary on your reasons for your addition. -->

### Checklist

- [x] I followed the style considerations for this project
- [x] I have added tests to my feature to prove my changes work
- [x] I have added documentation explaining what this new feature does
- [x] I abide by the security policy of the project

## Links

<!-- In case you changes fix an existing issue please link it below: -->

Fixes:

- [x] DONE

## Documentation

<!-- Provide a description about documentation changes necessary or done here. -->

- No documentation needed
<br/>

- [x] DONE

